### PR TITLE
No32_new_no_27_company_trading_amount_0permit

### DIFF
--- a/src/main/java/com/example/service/TransactionAmountService.java
+++ b/src/main/java/com/example/service/TransactionAmountService.java
@@ -72,7 +72,7 @@ public class TransactionAmountService {
 			return false;
 		}
 		// 金額が0以上か
-		if (entity.getPrice() <= 0) {
+		if (entity.getPrice() < 0) {
 			return false;
 		}
 		// 金額が10億円以下か


### PR DESCRIPTION
### 概要
取引金額の金額は0も入力可の認識ですが、現在入力できないようになっています。

設計に沿った入力となるように修正をお願いします。